### PR TITLE
created tests for total_cumulative_deaths

### DIFF
--- a/tests/testthat/test-canadacovidmetrics.R
+++ b/tests/testthat/test-canadacovidmetrics.R
@@ -8,7 +8,7 @@ test_that("Function returns a dataframe", {
 
 
   # total_cumulative_deaths
-
+  expect_true(is.data.frame(total_cumulative_deaths()))
 
   # total_cumulative_vaccine_completion
   expect_true(is.data.frame(total_cumulative_cases()))
@@ -23,7 +23,7 @@ test_that("Function default args return non-empty dataframe", {
 
 
   # total_cumulative_deaths
-
+  expect_false(is.null(dim(total_cumulative_deaths())))
 
   # total_cumulative_vaccine_completion
   expect_false(is.null(dim(total_cumulative_vaccine_completion())))
@@ -39,7 +39,7 @@ test_that("Function returns dataframe with correct columns", {
 
 
   # total_cumulative_deaths
-
+  expect_true(all(colnames(total_cumulative_deaths()) == c("cumulative_deaths", "date_death_report", "deaths", "province")))
 
   # total_cumulative_vaccine_completion
   expect_true(all(colnames(total_cumulative_vaccine_completion()) == c("cases", "cumulative_cases", "date_report", "province")))
@@ -54,7 +54,8 @@ test_that("Function returns data filtered to specified date", {
 
 
   # total_cumulative_deaths
-
+  expect_true(length(unique(total_cumulative_deaths(date='01-11-2021')$date)) == 1 &&
+                '01-11-2021' %in% unique(total_cumulative_deaths(date='01-11-2021')$date))
 
   # total_cumulative_vaccine_completion
   expect_true(length(unique(total_cumulative_vaccine_completion(date='01-11-2021')$date)) == 1 &&
@@ -62,12 +63,12 @@ test_that("Function returns data filtered to specified date", {
 
 })
 
-test_that("Function returns data filtered to specified date", {
-  expect_true(length(unique(total_cumulative_recovered_cases(date='01-11-2021')$date)) == 1 && 
-                '01-11-2021' %in% unique(total_cumulative_recovered_cases(date='01-11-2021')$date))
-  # add your function here
-
-})
+#test_that("Function returns data filtered to specified date", {
+#  expect_true(length(unique(total_cumulative_recovered_cases(date='01-11-2021')$date)) == 1 && 
+#                '01-11-2021' %in% unique(total_cumulative_recovered_cases(date='01-11-2021')$date))
+#  # add your function here
+#
+#})
 
 test_that("Function returns error with invalid location argument", {
   expect_error(loc_format_check('CAN'))


### PR DESCRIPTION
Part of the code for total_cumulative_recovered_cases is commented out, seems that part is repeated. @LukeAC Please see if it's ok to remove that part.